### PR TITLE
fix: initialize express server

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,13 @@
 const express = require('express');
-// more code...
+const http = require('http');
+const path = require('path');
 
-server.listen(PORT, ()=>{
-  console.log('Server listening on http://localhost:'+PORT);
+const app = express();
+const server = http.createServer(app);
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+server.listen(PORT, () => {
+  console.log('Server listening on http://localhost:' + PORT);
 });


### PR DESCRIPTION
## Summary
- define express app and HTTP server
- serve static public directory and start listening

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68badeb9638883299eadadf8d21aee03