### PR TITLE
Enable basic Socket.IO chat functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,15 @@
-# TeleIgorGram v4 (fixed)
+# TeleIgorGram
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+Простое приложение чата на Node.js и Socket.IO.
 
-Функции:
-- Регистрация/логин (JWT в httpOnly cookie)
-- Комнаты и личные сообщения (DM)
-- Вложения (картинки/файлы), предпросмотр изображений
-- Реакции, пины, редактирование/удаление
-- Индикатор «печатает…», пагинация, аватары
-- Поиск (SQLite FTS5 при наличии)
-- Защита: helmet, rate-limit
+## Возможности
+- Вход по имени пользователя
+- Обмен сообщениями в реальном времени
 
-## Запуск локально
+## Запуск
 ```bash
 npm install
 npm start
-# http://localhost:3000
+# Открыть http://localhost:3000
 ```
 
-## Переменные окружения
-- `JWT_SECRET` (обязательно на проде)
-- `ADMIN_USERNAMES` (напр. `igor,admin`)
-- `MAX_UPLOAD_MB` (по умолчанию 5)
-- `NODE_VERSION` (18)

--- a/public/app.js
+++ b/public/app.js
@@ -1,8 +1,47 @@
+const socket = io();
 
-const loginForm = document.querySelector('#login-form');
-const registerForm = document.querySelector('#register-form');
-const tabLogin = document.querySelector('#tab-login');
-const tabRegister = document.querySelector('#tab-register');
-const authError = document.querySelector('#auth-error');
+const authCard = document.getElementById('auth-card');
+const chatCard = document.getElementById('chat-card');
+const loginForm = document.getElementById('login-form');
+const loginInput = document.getElementById('login-username');
+const authError = document.getElementById('auth-error');
 
-// more code...
+const meName = document.getElementById('me-name');
+const messages = document.getElementById('messages');
+const messageForm = document.getElementById('message-form');
+const messageInput = document.getElementById('message-input');
+
+// Handle login
+loginForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const name = loginInput.value.trim();
+  if (!name) {
+    authError.textContent = 'Введите логин';
+    return;
+  }
+  socket.emit('login', name);
+});
+
+socket.on('login:success', (name) => {
+  meName.textContent = name;
+  authCard.style.display = 'none';
+  chatCard.style.display = 'block';
+});
+
+// Handle incoming messages
+socket.on('message', ({ username, text }) => {
+  const li = document.createElement('li');
+  li.textContent = `${username}: ${text}`;
+  messages.appendChild(li);
+  messages.scrollTop = messages.scrollHeight;
+});
+
+// Send a new message
+messageForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const text = messageInput.value.trim();
+  if (!text) return;
+  socket.emit('message', text);
+  messageInput.value = '';
+});
+

--- a/server.js
+++ b/server.js
@@ -1,6 +1,37 @@
 const express = require('express');
-// more code...
+const http = require('http');
+const path = require('path');
+const { Server } = require('socket.io');
 
-server.listen(PORT, ()=>{
-  console.log('Server listening on http://localhost:'+PORT);
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+io.on('connection', (socket) => {
+  let username;
+
+  socket.on('login', (name) => {
+    username = name && name.trim() ? name.trim() : 'Anonymous';
+    socket.emit('login:success', username);
+    socket.broadcast.emit('message', { username: 'system', text: `${username} joined` });
+  });
+
+  socket.on('message', (text) => {
+    if (!username || !text) return;
+    const msg = { username, text };
+    io.emit('message', msg);
+  });
+
+  socket.on('disconnect', () => {
+    if (username) {
+      io.emit('message', { username: 'system', text: `${username} left` });
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log('Server listening on http://localhost:' + PORT);
 });


### PR DESCRIPTION
## Summary
- integrate Socket.IO server to broadcast chat messages
- add client-side logic for username login and messaging
- document simple chat usage in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm start` (server logs "Server listening on http://localhost:3000")
- `curl -I http://localhost:3000/socket.io/socket.io.js`

------
https://chatgpt.com/codex/tasks/task_e_68badeb9638883299eadadf8d21aee03