### PR TITLE
Simplify chat UI and add logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,15 @@
-# TeleIgorGram v4 (fixed)
+# TeleIgorGram
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+Простое приложение чата на Node.js и Socket.IO.
 
-Функции:
-- Регистрация/логин (JWT в httpOnly cookie)
-- Комнаты и личные сообщения (DM)
-- Вложения (картинки/файлы), предпросмотр изображений
-- Реакции, пины, редактирование/удаление
-- Индикатор «печатает…», пагинация, аватары
-- Поиск (SQLite FTS5 при наличии)
-- Защита: helmet, rate-limit
+## Возможности
+- Вход по имени пользователя
+- Обмен сообщениями в реальном времени
 
-## Запуск локально
+## Запуск
 ```bash
 npm install
 npm start
-# http://localhost:3000
+# Открыть http://localhost:3000
 ```
 
-## Переменные окружения
-- `JWT_SECRET` (обязательно на проде)
-- `ADMIN_USERNAMES` (напр. `igor,admin`)
-- `MAX_UPLOAD_MB` (по умолчанию 5)
-- `NODE_VERSION` (18)

--- a/public/app.js
+++ b/public/app.js
@@ -1,8 +1,55 @@
+// Client-side logic for the simple chat
+const socket = io();
 
-const loginForm = document.querySelector('#login-form');
-const registerForm = document.querySelector('#register-form');
-const tabLogin = document.querySelector('#tab-login');
-const tabRegister = document.querySelector('#tab-register');
-const authError = document.querySelector('#auth-error');
+const authCard = document.getElementById('auth-card');
+const chatCard = document.getElementById('chat-card');
+const loginForm = document.getElementById('login-form');
+const loginInput = document.getElementById('login-username');
+const authError = document.getElementById('auth-error');
+const logoutBtn = document.getElementById('logout-btn');
 
-// more code...
+const meName = document.getElementById('me-name');
+const messages = document.getElementById('messages');
+const messageForm = document.getElementById('message-form');
+const messageInput = document.getElementById('message-input');
+
+// Handle login
+loginForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const name = loginInput.value.trim();
+  if (!name) {
+    authError.textContent = 'Введите логин';
+    return;
+  }
+  socket.emit('login', name);
+});
+
+socket.on('login:success', (name) => {
+  meName.textContent = name;
+  authCard.style.display = 'none';
+  chatCard.style.display = 'block';
+});
+
+// Handle incoming messages
+socket.on('message', ({ username, text }) => {
+  const li = document.createElement('li');
+  li.textContent = `${username}: ${text}`;
+  messages.appendChild(li);
+  messages.scrollTop = messages.scrollHeight;
+});
+
+// Send a new message
+messageForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const text = messageInput.value.trim();
+  if (!text) return;
+  socket.emit('message', text);
+  messageInput.value = '';
+});
+
+// Logout and reset state
+logoutBtn.addEventListener('click', () => {
+  socket.disconnect();
+  window.location.reload();
+});
+

--- a/public/index.html
+++ b/public/index.html
@@ -10,50 +10,21 @@
   <div class="container">
     <h1>Простой чат</h1>
     <div id="auth-card" class="card">
-      <div class="tabs">
-        <button id="tab-login" class="active">Войти</button>
-        <button id="tab-register">Регистрация</button>
-      </div>
       <form id="login-form">
         <div class="row">
           <input id="login-username" placeholder="Логин" />
-          <input id="login-password" type="password" placeholder="Пароль" />
           <button type="submit">Войти</button>
         </div>
+        <div id="auth-error" style="color:#fca5a5;margin-top:6px;"></div>
       </form>
-      <form id="register-form" style="display:none">
-        <div class="row">
-          <input id="register-username" placeholder="Логин" />
-          <input id="register-password" type="password" placeholder="Пароль (>=6)" />
-          <button type="submit">Зарегистрироваться</button>
-        </div>
-      </form>
-      <div id="auth-error" style="color:#fca5a5;margin-top:6px;"></div>
     </div>
 
     <div id="chat-card" class="card" style="display:none">
       <div class="hello">Здравствуйте, <span id="me-name"></span>!
-        <label class="avatar-label"><input id="avatar-input" type="file" accept="image/*" hidden /><span class="avatar-btn">🖼️ Аватар</span></label>
         <button id="logout-btn" style="float:right">Выйти</button>
       </div>
 
-      <div class="chat-actions">
-        <input id="search-input" placeholder="поиск..." />
-        <button id="search-btn" type="button">Найти</button>
-        <button id="show-pins" type="button">Пины</button>
-        <input id="file-input" type="file" hidden />
-        <button id="attach-btn" type="button">📎</button>
-        <select id="room-select">
-          <option value="global">#global</option>
-        </select>
-        <input id="dm-user" placeholder="DM: username" />
-        <button id="dm-open" type="button">Открыть DM</button>
-      </div>
-
-      <div id="pins" class="pins hidden"></div>
-      <div class="load-more-wrap"><button id="load-more" type="button">Загрузить ещё</button></div>
       <ul id="messages" class="messages"></ul>
-      <div id="typing" class="typing hidden"></div>
 
       <form id="message-form" class="message-form">
         <input id="message-input" placeholder="Сообщение..." />

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,23 +1,8 @@
-body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu; background:#0b1220; color:#e5e7eb; margin:0}
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu;background:#0b1220;color:#e5e7eb;margin:0}
 .container{max-width:900px;margin:40px auto;padding:0 16px}
 .card{background:#111827;border:1px solid #1f2937;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.3);padding:20px}
 h1{text-align:center;margin:16px 0 24px}
-.tabs{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px}
-.tabs button{padding:10px;border-radius:12px;border:1px solid #334155;background:#0b1324;color:#e5e7eb;cursor:pointer}
-.tabs button.active{outline:2px solid #3b82f6}
 input,button,select,textarea{background:#0b1324;border:1px solid #334155;color:#e5e7eb;border-radius:12px;padding:10px}
 form .row{display:grid;gap:8px;margin:8px 0}
-.message-form{display:grid;grid-template-columns: auto 1fr auto;gap:8px;margin-top:8px}
+.message-form{display:grid;grid-template-columns:auto 1fr auto;gap:8px;margin-top:8px}
 .messages{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:10px;max-height:420px;overflow:auto;border:1px solid #1f2937;padding:10px;border-radius:12px;background:#0b1324}
-.message .message-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:4px}
-.message .reactions{display:flex;gap:6px;margin-top:6px}
-.react-pill{background:#1f2937;border:1px solid #333;border-radius:999px;padding:2px 8px;cursor:pointer}
-.attachment img{max-width:280px;border-radius:8px;border:1px solid #223}
-.chat-actions{display:flex;gap:8px;align-items:center;margin:8px 0}
-.load-more-wrap{text-align:center;margin:8px 0}
-#typing{font-size:12px;color:#93c5fd;margin:6px 0}
-#typing.hidden{display:none}
-#pins{display:grid;gap:8px;margin-bottom:8px}
-#pins.hidden{display:none}
-.pin{background:#0b1220;border:1px dashed #2a3348;padding:8px;border-radius:10px}
-.edit-mark{font-size:11px;color:#94a3b8;margin-left:6px}

--- a/server.js
+++ b/server.js
@@ -1,6 +1,38 @@
+// Basic chat server using Express and Socket.IO
 const express = require('express');
-// more code...
+const http = require('http');
+const path = require('path');
+const { Server } = require('socket.io');
 
-server.listen(PORT, ()=>{
-  console.log('Server listening on http://localhost:'+PORT);
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+io.on('connection', (socket) => {
+  let username;
+
+  socket.on('login', (name) => {
+    username = name && name.trim() ? name.trim() : 'Anonymous';
+    socket.emit('login:success', username);
+    socket.broadcast.emit('message', { username: 'system', text: `${username} joined` });
+  });
+
+  socket.on('message', (text) => {
+    if (!username || !text) return;
+    const msg = { username, text };
+    io.emit('message', msg);
+  });
+
+  socket.on('disconnect', () => {
+    if (username) {
+      io.emit('message', { username: 'system', text: `${username} left` });
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log('Server listening on http://localhost:' + PORT);
 });


### PR DESCRIPTION
## Summary
- streamline index.html to only include working login, chat, and logout features
- add logout handler to client script for resetting the session
- trim stylesheet to match simplified interface
- document server and client scripts for the Socket.IO chat

## Testing
- `npm test` (fails: Missing script: "test")
- `node server.js` & `curl -I http://localhost:3000/socket.io/socket.io.js`


------
https://chatgpt.com/codex/tasks/task_e_68badeb9638883299eadadf8d21aee03